### PR TITLE
Bump to 2.2.20-Beta2 by introducing KtDiagnosticsContainer

### DIFF
--- a/compiler-plugin/src/io/github/nomisrev/typedapi/compiler/plugin/fir/Errors.kt
+++ b/compiler-plugin/src/io/github/nomisrev/typedapi/compiler/plugin/fir/Errors.kt
@@ -1,34 +1,26 @@
 package io.github.nomisrev.typedapi.compiler.plugin.fir
 
-import org.jetbrains.kotlin.diagnostics.DiagnosticFactory1DelegateProvider
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticFactoryToRendererMap
 import org.jetbrains.kotlin.diagnostics.KtDiagnosticRenderers.CLASS_ID
-import org.jetbrains.kotlin.diagnostics.Severity
-import org.jetbrains.kotlin.diagnostics.SourceElementPositioningStrategies
+import org.jetbrains.kotlin.diagnostics.KtDiagnosticsContainer
+import org.jetbrains.kotlin.diagnostics.error1
 import org.jetbrains.kotlin.diagnostics.rendering.BaseDiagnosticRendererFactory
-import org.jetbrains.kotlin.diagnostics.rendering.RootDiagnosticRendererFactory
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtClass
 
-object Errors : BaseDiagnosticRendererFactory() {
+internal object TypedApiDiagnostics : KtDiagnosticsContainer() {
+    val CLASS_EXPECTED_ERROR by error1<KtClass, ClassId>()
 
-    val CLASS_EXPECTED by DiagnosticFactory1DelegateProvider<ClassId>(
-        severity = Severity.ERROR,
-        positioningStrategy = SourceElementPositioningStrategies.DEFAULT,
-        psiType = KtClass::class,
-    )
+    override fun getRendererFactory(): BaseDiagnosticRendererFactory = Errors
 
-    @Suppress("ktlint:standard:property-naming")
-    override val MAP: KtDiagnosticFactoryToRendererMap =
-        KtDiagnosticFactoryToRendererMap("ExposedPlugin").apply {
-            put(
-                CLASS_EXPECTED,
+    private object Errors : BaseDiagnosticRendererFactory() {
+        override val MAP: KtDiagnosticFactoryToRendererMap by
+        KtDiagnosticFactoryToRendererMap("ExposedPlugin") {
+            it.put(
+                CLASS_EXPECTED_ERROR,
                 "Declaration annotation with @Endpoint must be a regular class, but found {0}.",
-                CLASS_ID,
+                CLASS_ID
             )
         }
-
-    init {
-        RootDiagnosticRendererFactory.registerFactory(this)
     }
 }

--- a/compiler-plugin/src/io/github/nomisrev/typedapi/compiler/plugin/fir/FirClassChecker.kt
+++ b/compiler-plugin/src/io/github/nomisrev/typedapi/compiler/plugin/fir/FirClassChecker.kt
@@ -41,6 +41,5 @@ class FirClassChecker(private val module: PluginContext) :
             reporter.reportOn(declaration.source, TypedApiDiagnostics.CLASS_EXPECTED_ERROR, declaration.classId)
             return
         }
-
     }
 }

--- a/compiler-plugin/src/io/github/nomisrev/typedapi/compiler/plugin/fir/FirClassChecker.kt
+++ b/compiler-plugin/src/io/github/nomisrev/typedapi/compiler/plugin/fir/FirClassChecker.kt
@@ -1,8 +1,6 @@
 package io.github.nomisrev.typedapi.compiler.plugin.fir
 
 import io.github.nomisrev.typedapi.compiler.plugin.PluginContext
-import org.jetbrains.kotlin.DeprecatedForRemovalCompilerApi
-import org.jetbrains.kotlin.descriptors.isClass
 import org.jetbrains.kotlin.diagnostics.DiagnosticReporter
 import org.jetbrains.kotlin.diagnostics.reportOn
 import org.jetbrains.kotlin.fir.FirSession
@@ -10,22 +8,14 @@ import org.jetbrains.kotlin.fir.analysis.checkers.MppCheckerKind
 import org.jetbrains.kotlin.fir.analysis.checkers.context.CheckerContext
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.DeclarationCheckers
 import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirClassChecker
+import org.jetbrains.kotlin.fir.analysis.checkers.declaration.FirDeclarationChecker
 import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtension
 import org.jetbrains.kotlin.fir.declarations.FirClass
 import org.jetbrains.kotlin.fir.declarations.getAnnotationByClassId
-import org.jetbrains.kotlin.fir.declarations.primaryConstructorIfAny
 import org.jetbrains.kotlin.fir.declarations.utils.classId
-import org.jetbrains.kotlin.fir.expressions.FirAnnotation
-import org.jetbrains.kotlin.fir.expressions.FirGetClassCall
-import org.jetbrains.kotlin.fir.resolve.isSubclassOf
-import org.jetbrains.kotlin.fir.resolve.toRegularClassSymbol
-import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
-import org.jetbrains.kotlin.fir.symbols.impl.FirRegularClassSymbol
 import org.jetbrains.kotlin.fir.types.renderReadableWithFqNames
 import org.jetbrains.kotlin.fir.types.resolvedType
 import org.jetbrains.kotlin.name.ClassId
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
 
 class FirCheckers(
     session: FirSession,
@@ -33,35 +23,24 @@ class FirCheckers(
 ) : FirAdditionalCheckersExtension(session) {
     override val declarationCheckers: DeclarationCheckers =
         object : DeclarationCheckers() {
-            override val classCheckers: Set<FirClassChecker> = setOf(ConstructorToTableChecker(module))
+            override val classCheckers: Set<FirClassChecker> = setOf(FirClassChecker(module))
         }
 }
 
-@OptIn(DeprecatedForRemovalCompilerApi::class)
-class ConstructorToTableChecker(
-    private val module: PluginContext,
-) : FirClassChecker(MppCheckerKind.Common) {
-    override fun check(
-        declaration: FirClass,
-        context: CheckerContext,
-        reporter: DiagnosticReporter,
-    ) {
+class FirClassChecker(private val module: PluginContext) :
+    FirDeclarationChecker<FirClass>(MppCheckerKind.Common) {
+    context(context: CheckerContext, reporter: DiagnosticReporter)
+    override fun check(declaration: FirClass) {
         val annotation =
-            declaration.getAnnotationByClassId(ClassId.topLevel(module.classIds.annotation), context.session)
-        if (annotation == null) return
+            declaration.getAnnotationByClassId(ClassId.topLevel(module.classIds.annotation), context.session) ?: return
 
         module.logger.log { "annotation: ${annotation.resolvedType.renderReadableWithFqNames()}" }
         module.logger.log { "class: ${declaration.status.isData}" }
         module.logger.log { "class: ${declaration.classKind}" }
         if (declaration.status.isData) {
-            reporter.reportOn(
-                declaration.source,
-                Errors.CLASS_EXPECTED,
-                declaration.classId,
-                context,
-            )
+            reporter.reportOn(declaration.source, TypedApiDiagnostics.CLASS_EXPECTED_ERROR, declaration.classId)
             return
         }
+
     }
 }
-

--- a/compiler-plugin/src/io/github/nomisrev/typedapi/compiler/plugin/ir/MyCodeIrGenerator.kt
+++ b/compiler-plugin/src/io/github/nomisrev/typedapi/compiler/plugin/ir/MyCodeIrGenerator.kt
@@ -146,11 +146,6 @@ class MyCodeIrGenerator(
         super.visitConstructor(declaration, data)
     }
 
-//    override fun visitSimpleFunction(declaration: IrSimpleFunction, data: Nothing?) {
-//        super.visitSimpleFunction(declaration, data)
-//
-//    }
-
     override fun visitFunction(declaration: IrFunction, data: Nothing?) {
         if (declaration.origin is IrDeclarationOrigin.GeneratedByPlugin) {
             if (!httpRequestValueIdentifiers.contains(declaration.name)) {

--- a/compiler-plugin/test-fixtures/io/github/nomisrev/typedapi/compiler/plugin/services/ClasspathBasedStandardLibrariesPathProvider.kt
+++ b/compiler-plugin/test-fixtures/io/github/nomisrev/typedapi/compiler/plugin/services/ClasspathBasedStandardLibrariesPathProvider.kt
@@ -66,6 +66,8 @@ object ClasspathBasedStandardLibrariesPathProvider : KotlinStandardLibrariesPath
 
     override fun kotlinTestJsKLib(): File = getFile("kotlin-test-js")
 
+    override fun commonStdlibForTests(): File = getFile("kotlin-common-stdlib")
+
     override fun scriptingPluginFilesForTests(): Collection<File> {
         TODO("KT-67573")
     }

--- a/compiler-plugin/testData/box/body.fir.ir.txt
+++ b/compiler-plugin/testData/box/body.fir.ir.txt
@@ -76,7 +76,7 @@ FILE fqName:my.test fileName:/body.kt
             then: RETURN type=kotlin.Nothing from='public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in my.test.User'
               CONST Boolean type=kotlin.Boolean value=false
         VAR IR_TEMPORARY_VARIABLE name:tmp_0 type:my.test.User [val]
-          TYPE_OP type=my.test.User origin=CAST typeOperand=my.test.User
+          TYPE_OP type=my.test.User origin=IMPLICIT_CAST typeOperand=my.test.User
             GET_VAR 'other: kotlin.Any? declared in my.test.User.equals' type=kotlin.Any? origin=null
         WHEN type=kotlin.Unit origin=null
           BRANCH
@@ -286,7 +286,8 @@ FILE fqName:my.test fileName:/body.kt
               BRANCH
                 if: CONST Boolean type=kotlin.Boolean value=true
                 then: CALL 'public abstract fun <get-key> (): K of kotlin.collections.Map.Entry declared in kotlin.collections.Map.Entry' type=kotlin.Any? origin=GET_PROPERTY
-                  ARG <this>: GET_VAR 'val tmp_1: kotlin.collections.Map.Entry<kotlin.Any?, io.github.nomisrev.typedapi.Input<kotlin.Any?>>? declared in my.test.box' type=kotlin.collections.Map.Entry<kotlin.Any?, io.github.nomisrev.typedapi.Input<kotlin.Any?>>? origin=null
+                  ARG <this>: TYPE_OP type=kotlin.collections.Map.Entry<kotlin.Any?, io.github.nomisrev.typedapi.Input<kotlin.Any?>> origin=IMPLICIT_CAST typeOperand=kotlin.collections.Map.Entry<kotlin.Any?, io.github.nomisrev.typedapi.Input<kotlin.Any?>>
+                    GET_VAR 'val tmp_1: kotlin.collections.Map.Entry<kotlin.Any?, io.github.nomisrev.typedapi.Input<kotlin.Any?>>? declared in my.test.box' type=kotlin.collections.Map.Entry<kotlin.Any?, io.github.nomisrev.typedapi.Input<kotlin.Any?>>? origin=null
       WHEN type=kotlin.Unit origin=IF
         BRANCH
           if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
@@ -307,5 +308,6 @@ FILE fqName:my.test fileName:/body.kt
               CONST String type=kotlin.String value="Expected "
               GET_VAR 'val testUser: my.test.User declared in my.test.box' type=my.test.User origin=null
               CONST String type=kotlin.String value=", got "
-              GET_VAR 'val bodyValue: my.test.User? declared in my.test.box' type=my.test.User? origin=null
+              TYPE_OP type=my.test.User origin=IMPLICIT_CAST typeOperand=my.test.User
+                GET_VAR 'val bodyValue: my.test.User? declared in my.test.box' type=my.test.User? origin=null
 FILE fqName:my.test fileName:__GENERATED DECLARATIONS__.kt

--- a/compiler-plugin/testData/box/header.fir.ir.txt
+++ b/compiler-plugin/testData/box/header.fir.ir.txt
@@ -146,7 +146,8 @@ FILE fqName:my.test fileName:/header.kt
             BRANCH
               if: CONST Boolean type=kotlin.Boolean value=true
               then: CALL 'public abstract fun <get-key> (): K of kotlin.collections.Map.Entry declared in kotlin.collections.Map.Entry' type=kotlin.Any? origin=GET_PROPERTY
-                ARG <this>: GET_VAR 'val tmp_0: kotlin.collections.Map.Entry<kotlin.Any?, io.github.nomisrev.typedapi.Input<kotlin.Any?>>? declared in my.test.box' type=kotlin.collections.Map.Entry<kotlin.Any?, io.github.nomisrev.typedapi.Input<kotlin.Any?>>? origin=null
+                ARG <this>: TYPE_OP type=kotlin.collections.Map.Entry<kotlin.Any?, io.github.nomisrev.typedapi.Input<kotlin.Any?>> origin=IMPLICIT_CAST typeOperand=kotlin.collections.Map.Entry<kotlin.Any?, io.github.nomisrev.typedapi.Input<kotlin.Any?>>
+                  GET_VAR 'val tmp_0: kotlin.collections.Map.Entry<kotlin.Any?, io.github.nomisrev.typedapi.Input<kotlin.Any?>>? declared in my.test.box' type=kotlin.collections.Map.Entry<kotlin.Any?, io.github.nomisrev.typedapi.Input<kotlin.Any?>>? origin=null
       RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in my.test'
         WHEN type=kotlin.String origin=IF
           BRANCH

--- a/compiler-plugin/testData/diagnostics/invalidParameterType.kt
+++ b/compiler-plugin/testData/diagnostics/invalidParameterType.kt
@@ -22,3 +22,6 @@ fun box(): String {
     val value = InvalidTypeEndpoint(ComplexType("test"))
     return "OK"
 }
+
+/* GENERATED_FIR_TAGS: classDeclaration, functionDeclaration, nullableType, override, primaryConstructor,
+propertyDeclaration, propertyDelegate, stringLiteral */

--- a/compiler-plugin/testData/diagnostics/pathWithParams.kt
+++ b/compiler-plugin/testData/diagnostics/pathWithParams.kt
@@ -18,3 +18,6 @@ fun box(): String {
     val path = value.path()
     return if (path == "/path/1/second/2") "OK" else path
 }
+
+/* GENERATED_FIR_TAGS: classDeclaration, functionDeclaration, nullableType, primaryConstructor, propertyDeclaration,
+propertyDelegate, stringLiteral */

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.2.0"
+kotlin = "2.2.20-Beta2"
 kotlinx-coroutines = "1.8.0"
 
 [libraries]

--- a/ktor-typed-api/build.gradle.kts
+++ b/ktor-typed-api/build.gradle.kts
@@ -11,18 +11,18 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":typed-api"))
-                api("io.ktor:ktor-server-core:3.1.3")
-                api("io.ktor:ktor-client-core:3.1.3")
-                api("io.ktor:ktor-serialization-kotlinx-json:3.1.3")
+                api(ktorLibs.server.core)
+                api(ktorLibs.client.core)
+                api(ktorLibs.serialization.kotlinx.json)
             }
         }
         commonTest {
             dependencies {
                 implementation(libs.kotlin.test)
-                implementation("io.ktor:ktor-server-test-host:3.1.3")
-                implementation("io.ktor:ktor-client-content-negotiation:3.1.3")
-                implementation("io.ktor:ktor-server-content-negotiation:3.1.3")
-                implementation("com.charleskorn.kaml:kaml:0.80.1")
+                implementation(ktorLibs.server.testHost)
+                implementation(ktorLibs.server.contentNegotiation)
+                implementation(ktorLibs.client.contentNegotiation)
+                implementation(libs.kaml)
             }
         }
     }

--- a/samples/gradle.properties
+++ b/samples/gradle.properties
@@ -3,7 +3,6 @@ org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.configuration-cache=true
 android.useAndroidX=true
-kotlin.native.useEmbeddableCompilerJar=true
 kotlin.apple.xcodeCompatibility.nowarn=true
 kotlin.suppressGradlePluginWarnings=IncorrectCompileOnlyDependencyWarning
 kotlin.compiler.suppressExperimentalICOptimizationsWarning=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("ktorLibs") {
-            from("io.ktor:ktor-version-catalog:3.2.1")
+            from("io.ktor:ktor-version-catalog:3.2.3")
         }
     }
 }

--- a/typed-api-docs/build.gradle.kts
+++ b/typed-api-docs/build.gradle.kts
@@ -12,6 +12,6 @@ kotlin {
 dependencies {
     api(project(":typed-api"))
     api(project(":parser"))
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation(libs.kotlin.reflect)
     testImplementation(libs.kotlin.test)
 }

--- a/typed-api/src/commonMain/kotlin/io/github/nomisrev/typedapi/MapEndpointAPI.kt
+++ b/typed-api/src/commonMain/kotlin/io/github/nomisrev/typedapi/MapEndpointAPI.kt
@@ -2,6 +2,7 @@ package io.github.nomisrev.typedapi
 
 import kotlin.properties.ReadOnlyProperty
 
+// TODO better name?
 class MapEndpointAPI(private val values: Map<String, Any?>) : EndpointAPI {
     constructor(vararg values: Pair<String, Any?>) : this(values.toMap())
 


### PR DESCRIPTION
## Summary

This pull request upgrades the project to **Ktor 2.2.20-Beta2** by introducing the new `KtDiagnosticsContainer`. This update ensures compatibility with the latest Ktor beta release and leverages improvements provided in the new diagnostics framework.

## Details

- **Upgrade to Ktor 2.2.20-Beta2**:  
  The project dependencies have been updated to use the 2.2.20-Beta2 release of Ktor.
- **Introduce `KtDiagnosticsContainer`**:  
  - Added a new diagnostics container for improved error handling and diagnostics.
  - Updated relevant code to integrate with the new diagnostics mechanism.
- **Compatibility Adjustments**:  
  - Refactored parts of the codebase to align with any breaking changes or new APIs introduced in 2.2.20-Beta2.
  - Ensured all tests pass and the project builds successfully with the new version.

## Checklist

- [x] Project builds with Ktor 2.2.20-Beta2
- [x] All tests pass
- [x] New diagnostics container is integrated and covered by tests
- [x] Documentation updated as needed
